### PR TITLE
Variable activation

### DIFF
--- a/tests/nn/modules/mid/inference/test_deterministic.py
+++ b/tests/nn/modules/mid/inference/test_deterministic.py
@@ -140,23 +140,24 @@ class TestActivateDelta:
 
 
 class TestActivateUnknownDistribution:
-    """activate with unsupported distribution → NotImplementedError."""
+    """activate with unsupported distribution → identity fallback."""
 
-    def test_raises(self):
+    def test_identity_fallback(self):
         var = _make_variable('c', Normal)
         inf = DeterministicInference.__new__(DeterministicInference)
         pred = torch.randn(4, 1)
-        with pytest.raises(NotImplementedError, match="Activation for distribution"):
-            inf.activate(pred, var)
+        result = inf.activate(pred, var)
+        torch.testing.assert_close(result, pred)
 
-    def test_raises_when_distribution_is_none(self):
+    def test_identity_when_distribution_is_none(self):
         """Variable whose distribution is None."""
         var = _make_variable('c', Bernoulli)
         var.distribution = None  # override to None
+        var.activation = lambda x: x  # match the fallback
         inf = DeterministicInference.__new__(DeterministicInference)
         pred = torch.randn(4, 1)
-        with pytest.raises(NotImplementedError):
-            inf.activate(pred, var)
+        result = inf.activate(pred, var)
+        torch.testing.assert_close(result, pred)
 
 
 # ===========================================================================

--- a/torch_concepts/nn/modules/mid/inference/ancestral.py
+++ b/torch_concepts/nn/modules/mid/inference/ancestral.py
@@ -3,8 +3,6 @@
 import inspect
 
 import torch
-from torch.distributions import Bernoulli, RelaxedBernoulli, \
-    OneHotCategorical, RelaxedOneHotCategorical
 
 from .forward import ForwardInference
 from ..models.variable import Variable
@@ -21,8 +19,9 @@ class AncestralSamplingInference(ForwardInference):
     realistic samples from the model and for tasks requiring stochastic predictions.
 
     The sampling respects the probabilistic structure:
-    - Samples from Bernoulli distributions using .sample()
-    - Uses reparameterization (.rsample()) for RelaxedBernoulli and RelaxedOneHotCategorical
+    - Uses reparameterization (.rsample()) when the distribution supports it
+    - Falls back to .sample() otherwise
+    - Passes logits or probs depending on the log_probs flag
     - Supports custom distribution kwargs (e.g., temperature for Gumbel-Softmax)
 
     Args:
@@ -111,9 +110,10 @@ class AncestralSamplingInference(ForwardInference):
         """
         Sample from the distribution parameterized by the raw CPD output.
 
-        * ``Bernoulli``  → ``.sample()``
-        * ``RelaxedBernoulli`` / ``RelaxedOneHotCategorical`` → ``.rsample()``
-        * Other           → ``.rsample()``
+        The method introspects the distribution's constructor to decide how
+        to pass ``pred`` (as ``logits``, ``probs``, or positional arg) and
+        uses ``has_rsample`` to choose between ``.rsample()`` and
+        ``.sample()``.
 
         Distribution kwargs are read from ``variable.dist_kwargs``.
 
@@ -137,18 +137,17 @@ class AncestralSamplingInference(ForwardInference):
         # retain only allowed dist kwargs
         dist_kwargs = {k: v for k, v in variable.dist_kwargs.items() if k in allowed}
 
-        if variable.distribution in [Bernoulli, OneHotCategorical, RelaxedBernoulli, RelaxedOneHotCategorical]:
-            if self.log_probs:
-                dist_kwargs['logits'] = pred
-            else:
-                dist_kwargs['probs'] = pred
+        # Decide how to pass pred based on the distribution's accepted params
+        if "logits" in allowed and self.log_probs:
+            dist_kwargs["logits"] = pred
+            dist = variable.distribution(**dist_kwargs)
+        elif "probs" in allowed and not self.log_probs:
+            dist_kwargs["probs"] = pred
+            dist = variable.distribution(**dist_kwargs)
+        else:
+            dist = variable.distribution(pred, **dist_kwargs)
 
-            if variable.distribution in [Bernoulli, OneHotCategorical]:
-                return variable.distribution(**dist_kwargs).sample()
-            elif variable.distribution in [RelaxedBernoulli, RelaxedOneHotCategorical]:
-                return variable.distribution(**dist_kwargs).rsample()
-
-        return variable.distribution(pred, **dist_kwargs).rsample()
+        return dist.rsample() if dist.has_rsample else dist.sample()
 
     # TODO: currently assumes discrete, to be extended to continuous 
     def ground_truth_to_evidence(self, value: torch.Tensor, cardinality: int) -> torch.Tensor:

--- a/torch_concepts/nn/modules/mid/inference/deterministic.py
+++ b/torch_concepts/nn/modules/mid/inference/deterministic.py
@@ -1,8 +1,6 @@
 """Deterministic inference for probabilistic graphical models."""
 
 import torch
-from torch.distributions import Bernoulli, Categorical, RelaxedBernoulli, RelaxedOneHotCategorical
-from torch_concepts.distributions import Delta
 
 from .forward import ForwardInference
 from ..models.variable import Variable
@@ -70,34 +68,21 @@ class DeterministicInference(ForwardInference):
     """
     def activate(self, pred: torch.Tensor, variable: Variable) -> torch.Tensor:
         """
-        Map logits to probabilities based on the variable's distribution.
+        Map logits to probabilities using the variable's activation.
 
-        * ``Bernoulli`` / ``RelaxedBernoulli``  → sigmoid
-        * ``Categorical`` / ``RelaxedOneHotCategorical`` → softmax
-        * Other           → identity (pass-through)
+        The activation function is stored on the :class:`Variable` instance
+        (defaulting to sigmoid for Bernoulli, softmax for Categorical,
+        identity for Delta, etc.).  Custom activations can be provided when
+        constructing the variable.
 
         Args:
             pred: Prediction tensor (logits).
             variable: The Variable whose prediction is being propagated.
 
         Returns:
-            torch.Tensor: Probability tensor in [0, 1].
+            torch.Tensor: Probability tensor.
         """
-        dist = getattr(variable, 'distribution', None)
-
-        # TODO: Move this logic to a more central place (e.g. Variable or CPD).
-        # allowing users to define custom distributions and activations.
-        if dist in (Bernoulli, RelaxedBernoulli):
-            return torch.sigmoid(pred)
-        elif dist in (Categorical, RelaxedOneHotCategorical):
-            return torch.softmax(pred, dim=-1)
-        elif dist is Delta:
-            return pred  # already deterministic
-        else:
-            raise NotImplementedError(
-                f"Activation for distribution {dist} not implemented. "
-                "Please implement in DeterministicInference.activate()."
-            )
+        return variable.activation(pred)
 
     def ground_truth_to_evidence(self, value: torch.Tensor, cardinality: int) -> torch.Tensor:
         """

--- a/torch_concepts/nn/modules/mid/models/variable.py
+++ b/torch_concepts/nn/modules/mid/models/variable.py
@@ -6,10 +6,21 @@ concept-based models. Variables can have different probability distributions
 and support hierarchical concept structures.
 """
 import torch
+from functools import partial
 from torch.distributions import Distribution, Bernoulli, Categorical, RelaxedBernoulli, RelaxedOneHotCategorical
-from typing import List, Dict, Any, Union, Optional, Type
+from typing import List, Dict, Any, Union, Optional, Type, Callable
 
 from .....distributions import Delta
+
+
+# Default logits → probabilities activations per distribution type.
+_DEFAULT_ACTIVATIONS: Dict[Type[Distribution], Callable[[torch.Tensor], torch.Tensor]] = {
+    Bernoulli: torch.sigmoid,
+    RelaxedBernoulli: torch.sigmoid,
+    Categorical: partial(torch.softmax, dim=-1),
+    RelaxedOneHotCategorical: partial(torch.softmax, dim=-1),
+    Delta: lambda x: x,
+}
 
 
 class Variable:
@@ -73,7 +84,8 @@ class Variable:
     def __new__(cls, concepts: Union[str, List[str]],
                 distribution: Union[Type[Distribution], List[Type[Distribution]]] = None,
                 size: Union[int, List[int]] = 1, metadata: Optional[Dict[str, Any]] = None,
-                dist_kwargs: Optional[Dict[str, Any]] = None):
+                dist_kwargs: Optional[Dict[str, Any]] = None,
+                activation: Optional[Callable[[torch.Tensor], torch.Tensor]] = None):
         """
         Create new Variable instance(s).
 
@@ -140,7 +152,8 @@ class Variable:
                 distribution=distribution_list[i],
                 size=size_list[i],
                 metadata=metadata.copy() if metadata else None,
-                dist_kwargs=dist_kwargs.copy() if dist_kwargs else None
+                dist_kwargs=dist_kwargs.copy() if dist_kwargs else None,
+                activation=activation,
             )
             new_vars.append(instance)
         return new_vars
@@ -149,7 +162,8 @@ class Variable:
                  distribution: Union[Type[Distribution], List[Type[Distribution]]] = None,
                  size: Union[int, List[int]] = 1,
                  metadata: Dict[str, Any] = None,
-                 dist_kwargs: Optional[Dict[str, Any]] = None):
+                 dist_kwargs: Optional[Dict[str, Any]] = None,
+                 activation: Optional[Callable[[torch.Tensor], torch.Tensor]] = None):
         """
         Initialize a Variable instance.
 
@@ -161,6 +175,10 @@ class Variable:
             dist_kwargs: Optional keyword arguments for the distribution
                 constructor (e.g., ``{'temperature': 0.5}`` for relaxed
                 distributions).
+            activation: Optional callable that maps logits to probabilities.
+                If ``None``, a default is chosen based on *distribution*
+                (e.g. sigmoid for Bernoulli, softmax for Categorical,
+                identity for Delta).  Pass a custom callable to override.
 
         Raises:
             ValueError: If Categorical variable doesn't have size > 1.
@@ -182,6 +200,10 @@ class Variable:
         self.size = size
         self.dist_kwargs = dist_kwargs if dist_kwargs is not None else {}
         self.metadata = metadata if metadata is not None else {}
+        if activation is not None:
+            self.activation = activation
+        else:
+            self.activation = _DEFAULT_ACTIVATIONS.get(distribution, lambda x: x)
 
     @property
     def out_features(self) -> int:
@@ -254,7 +276,8 @@ class ConceptVariable(Variable):
                  distribution: Union[Type[Distribution], List[Type[Distribution]]] = None,
                  size: Union[int, List[int]] = 1,
                  metadata: Dict[str, Any] = None,
-                 dist_kwargs: Optional[Dict[str, Any]] = None):
+                 dist_kwargs: Optional[Dict[str, Any]] = None,
+                 **kwargs):
         """
         Initialize a ConceptVariable instance.
         
@@ -265,11 +288,13 @@ class ConceptVariable(Variable):
             metadata: Optional metadata dictionary.
             dist_kwargs: Optional keyword arguments for the distribution
                 constructor (e.g., ``{'temperature': 0.5}``).
+            **kwargs: Additional keyword arguments forwarded to
+                :class:`Variable` (e.g. ``activation``).
         """
         if metadata is None:
             metadata = {}
         metadata['variable_type'] = 'concept'
-        super().__init__(concepts, distribution, size, metadata, dist_kwargs)
+        super().__init__(concepts, distribution, size, metadata, dist_kwargs, **kwargs)
 
 
 # Backward compatibility alias
@@ -316,7 +341,8 @@ class ExogenousVariable(Variable):
                  size: Union[int, List[int]] = 1,
                  concept_var: Optional['ConceptVariable'] = None,
                  metadata: Dict[str, Any] = None,
-                 dist_kwargs: Optional[Dict[str, Any]] = None):
+                 dist_kwargs: Optional[Dict[str, Any]] = None,
+                 **kwargs):
         """
         Initialize an ExogenousVariable instance.
         
@@ -327,13 +353,15 @@ class ExogenousVariable(Variable):
             concept_var: Optional reference to the related concept variable.
             metadata: Optional metadata dictionary.
             dist_kwargs: Optional keyword arguments for the distribution constructor.
+            **kwargs: Additional keyword arguments forwarded to
+                :class:`Variable` (e.g. ``activation``).
         """
         if metadata is None:
             metadata = {}
         metadata['variable_type'] = 'exogenous'
         if concept_var is not None:
             metadata['concept_var'] = concept_var
-        super().__init__(concepts, distribution, size, metadata, dist_kwargs)
+        super().__init__(concepts, distribution, size, metadata, dist_kwargs, **kwargs)
         self.concept_var = concept_var
 
 
@@ -381,7 +409,8 @@ class LatentVariable(Variable):
                  distribution: Union[Type[Distribution], List[Type[Distribution]]] = None,
                  size: Union[int, List[int]] = 1,
                  metadata: Dict[str, Any] = None,
-                 dist_kwargs: Optional[Dict[str, Any]] = None):
+                 dist_kwargs: Optional[Dict[str, Any]] = None,
+                 **kwargs):
         """
         Initialize a LatentVariable instance.
         
@@ -391,11 +420,13 @@ class LatentVariable(Variable):
             size: Dimensionality of the latent representation.
             metadata: Optional metadata dictionary.
             dist_kwargs: Optional keyword arguments for the distribution constructor.
+            **kwargs: Additional keyword arguments forwarded to
+                :class:`Variable` (e.g. ``activation``).
         """
         if metadata is None:
             metadata = {}
         metadata['variable_type'] = 'latent'
-        super().__init__(concepts, distribution, size, metadata, dist_kwargs)
+        super().__init__(concepts, distribution, size, metadata, dist_kwargs, **kwargs)
 
 
 # Backward compatibility alias


### PR DESCRIPTION
In this PR the hard coded activations are removed from the inference methods.
Specifically:
- the variable class now stores the activation (inferred from the distribution if not specified by the user);
- the activation function in the inference class just call the activation of the variable (when needed).