### PR TITLE
✨ Add prototype-grounded label-free CBM

### DIFF
--- a/doc/guides/using_high_level.rst
+++ b/doc/guides/using_high_level.rst
@@ -165,6 +165,61 @@ Expand each block below for an explanation and an example.
            loss.backward()
            optimizer.step()
 
+    **Label-free, prototype-grounded concepts.** When an external model puts
+    inputs and concept descriptions in a shared embedding space (for example,
+    CLIP image and text embeddings), ``PrototypeEmbeddingToConcept`` can keep
+    those concept meanings fixed. The caller supplies compatible embeddings;
+    PyC does not load the external model. The loop below uses only task labels
+    ``y_train``—it never receives concept ground truth:
+
+    .. code-block:: python
+
+       import torch
+       import torch.nn.functional as F
+       from torch_concepts import Annotations
+       from torch_concepts.nn import (
+           ConceptBottleneckModel, PrototypeEmbeddingToConcept,
+       )
+
+       annotations = Annotations(
+           labels=["striped", "red", "target"],
+           cardinalities=[1, 1, 2],
+           types=["binary", "binary", "categorical"],
+       )
+       # x_train and prototypes are embeddings from the same external space.
+       prototypes = F.normalize(torch.randn(2, 512), dim=-1)
+       prototype_by_concept = dict(zip(["striped", "red"], prototypes))
+
+       def prototype_encoder(in_embeddings, concept_annotations):
+           rows = torch.stack([
+               prototype_by_concept[name]
+               for name in concept_annotations.labels
+           ])
+           return PrototypeEmbeddingToConcept(
+               in_embeddings, concept_annotations, rows, temperature=12.0,
+           )
+
+       model = ConceptBottleneckModel(
+           input_size=512,
+           annotations=annotations,
+           task_names=["target"],
+           backbone=torch.nn.Identity(),
+           latent_size=512,
+           concept_encoder_factory=prototype_encoder,
+       )
+       optimizer = torch.optim.AdamW(model.parameters(), lr=1e-2)
+       for x_batch, y_batch in loader:  # y_batch is the task label only
+           out = model(input=x_batch, query=["target"])
+           loss = F.cross_entropy(out.logits["target"].tensor, y_batch)
+           optimizer.zero_grad()
+           loss.backward()
+           optimizer.step()
+
+    Cosine similarity is computed after L2-normalising both sides, so raw or
+    pre-normalised compatible embeddings are accepted. This validates the
+    CBM wiring and preserves externally supplied grounding; task labels alone
+    do not establish semantic concepts.
+
     **PyTorch Lightning.** Pass ``lightning=True`` together with a ``loss`` (either a standard
     |pytorch_logo| PyTorch loss or a |pyc_logo| :class:`~torch_concepts.nn.ConceptLoss`),
     optional ``metrics``, and an optimizer; then hand the model and a datamodule to a ``Trainer``:

--- a/doc/modules/low_level_api.rst
+++ b/doc/modules/low_level_api.rst
@@ -41,6 +41,7 @@ Encoders
    ConceptWhitening
    WhitenedEmbeddingToConcept
    CAVEmbeddingToConcept
+   PrototypeEmbeddingToConcept
 
 Predictors
 ----------

--- a/tests/nn/modules/high/models/test_cbm.py
+++ b/tests/nn/modules/high/models/test_cbm.py
@@ -14,10 +14,11 @@ import pytest
 import unittest
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributions import Bernoulli, OneHotCategorical, RelaxedBernoulli, RelaxedOneHotCategorical
 from torch_concepts.nn.modules.high.models.cbm import ConceptBottleneckModel
 from torch_concepts.nn.modules.high.base.learner import BaseLearner
-from torch_concepts.nn import MLP, DefaultActivation
+from torch_concepts.nn import MLP, DefaultActivation, PrototypeEmbeddingToConcept
 from torch_concepts.nn.modules.loss import ConceptLoss
 from torch_concepts.annotations import Annotations
 
@@ -330,6 +331,126 @@ class TestCBMFactory(unittest.TestCase):
         )
 
         self.assertFalse(isinstance(model, BaseLearner))
+
+
+class TestCBMConceptEncoderFactory(unittest.TestCase):
+    """Tests for custom, label-free concept encoders."""
+
+    def test_factory_receives_each_plate_annotation(self):
+        annotations = Annotations(
+            labels=["striped", "red", "target"],
+            cardinalities=[1, 1, 1],
+            types=["binary", "binary", "binary"],
+        )
+        received = []
+
+        def factory(in_embeddings, out_concepts):
+            received.append(tuple(out_concepts.labels))
+            return PrototypeEmbeddingToConcept(
+                in_embeddings,
+                out_concepts,
+                F.normalize(torch.randn(out_concepts.size, in_embeddings), dim=-1),
+            )
+
+        model = ConceptBottleneckModel(
+            input_size=4,
+            annotations=annotations,
+            task_names=["target"],
+            concept_encoder_factory=factory,
+        )
+        out = model(input=torch.randn(3, 4), query=["striped", "red", "target"])
+
+        assert received == [("striped", "red")]
+        assert _logits(out, ["striped", "red", "target"]).shape == (3, 3)
+
+    def test_factory_rejects_invalid_encoders_and_continuous_concepts(self):
+        binary = Annotations(labels=["concept", "task"], cardinalities=[1, 1])
+        with pytest.raises(TypeError, match="nn.Module"):
+            ConceptBottleneckModel(
+                input_size=4,
+                annotations=binary,
+                task_names=["task"],
+                concept_encoder_factory=lambda *_: object(),
+            )
+
+        continuous = Annotations(
+            labels=["amount", "task"],
+            cardinalities=[1, 1],
+            types=["continuous", "binary"],
+        )
+        with pytest.raises(ValueError, match="binary and categorical"):
+            ConceptBottleneckModel(
+                input_size=4,
+                annotations=continuous,
+                task_names=["task"],
+                concept_encoder_factory=lambda *_: nn.Identity(),
+            )
+
+    def test_default_encoder_path_is_unchanged(self):
+        annotations = Annotations(labels=["concept", "task"], cardinalities=[1, 1])
+        model = ConceptBottleneckModel(
+            input_size=4, annotations=annotations, task_names=["task"]
+        )
+        out = model(input=torch.randn(2, 4), query=["concept", "task"])
+        assert _logits(out, ["concept", "task"]).shape == (2, 2)
+
+
+class TestTaskOnlyPrototypeTraining(unittest.TestCase):
+    """Task-only optimisation with externally grounded prototypes."""
+
+    def test_training_uses_only_embeddings_and_task_labels(self):
+        torch.manual_seed(3)
+        embedding_size = 16
+        prototype_rows = F.normalize(torch.randn(2, embedding_size), dim=-1)
+        coefficients = torch.randn(512, 2)
+        x = F.normalize(
+            coefficients @ prototype_rows + 0.05 * torch.randn(512, embedding_size),
+            dim=-1,
+        )
+        y = (coefficients[:, 0] > 0).float()
+        annotations = Annotations(
+            labels=["prototype_a", "prototype_b", "task"],
+            cardinalities=[1, 1, 1],
+            types=["binary", "binary", "binary"],
+        )
+        prototype_by_concept = {
+            "prototype_a": prototype_rows[0],
+            "prototype_b": prototype_rows[1],
+        }
+
+        def factory(in_embeddings, out_concepts):
+            rows = torch.stack([
+                prototype_by_concept[name] for name in out_concepts.labels
+            ])
+            return PrototypeEmbeddingToConcept(in_embeddings, out_concepts, rows)
+
+        model = ConceptBottleneckModel(
+            input_size=embedding_size,
+            annotations=annotations,
+            task_names=["task"],
+            backbone=nn.Identity(),
+            latent_size=embedding_size,
+            concept_encoder_factory=factory,
+        )
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-2)
+        for _ in range(300):
+            out = model(input=x, query=["task"])
+            loss = F.binary_cross_entropy_with_logits(
+                out.logits["task"].tensor, y.unsqueeze(-1)
+            )
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        with torch.inference_mode():
+            logits = model(input=x, query=["task"]).logits["task"].tensor
+        accuracy = ((logits.sigmoid() > 0.5).squeeze(-1) == y.bool()).float().mean()
+        assert accuracy > 0.9
+        encoder = next(
+            module for module in model.modules()
+            if isinstance(module, PrototypeEmbeddingToConcept)
+        )
+        assert encoder.state_prototypes.grad is None
 
 
 class TestCBMUnifiedForward(unittest.TestCase):

--- a/tests/nn/modules/low/encoders/test_prototype.py
+++ b/tests/nn/modules/low/encoders/test_prototype.py
@@ -1,0 +1,98 @@
+"""Tests for PrototypeEmbeddingToConcept."""
+import pytest
+import torch
+
+from torch_concepts import Annotations
+from torch_concepts.nn import PrototypeEmbeddingToConcept
+from torch_concepts.nn.modules.low.encoders.prototype import (
+    PrototypeEmbeddingToConcept as PrototypeEmbeddingToConceptDeep,
+)
+
+
+def _binary_annotations(n_concepts=2):
+    return Annotations(
+        labels=[f"concept_{i}" for i in range(n_concepts)],
+        cardinalities=[1] * n_concepts,
+        types=["binary"] * n_concepts,
+    )
+
+
+class TestPrototypeConstruction:
+    def test_import_paths_agree(self):
+        assert PrototypeEmbeddingToConcept is PrototypeEmbeddingToConceptDeep
+
+    def test_buffers_are_frozen_and_sized_by_states(self):
+        ann = Annotations(
+            labels=["present", "color"],
+            states=[["present"], ["red", "blue"]],
+            types=["binary", "categorical"],
+        )
+        layer = PrototypeEmbeddingToConcept(4, ann, torch.randn(3, 4))
+
+        assert layer.state_prototypes.shape == (3, 4)
+        assert layer.temperature.item() == 12.0
+        assert len(list(layer.parameters())) == 0
+        assert layer.prototype_labels == ("present", "color:red", "color:blue")
+
+    def test_rejects_invalid_configuration(self):
+        ann = _binary_annotations()
+        with pytest.raises(ValueError, match="shape"):
+            PrototypeEmbeddingToConcept(4, ann, torch.randn(2, 3))
+        with pytest.raises(ValueError, match="positive"):
+            PrototypeEmbeddingToConcept(4, ann, torch.randn(2, 4), temperature=0)
+        with pytest.raises(ValueError, match="prototype labels"):
+            PrototypeEmbeddingToConcept(
+                4, ann, torch.randn(2, 4), prototype_labels=["only one"]
+            )
+
+        continuous = Annotations(
+            labels=["amount"], cardinalities=[1], types=["continuous"]
+        )
+        with pytest.raises(ValueError, match="binary and categorical"):
+            PrototypeEmbeddingToConcept(4, continuous, torch.randn(1, 4))
+
+
+class TestPrototypeForward:
+    def test_cosine_logits_and_leading_dimensions(self):
+        ann = _binary_annotations()
+        prototypes = torch.tensor([[3.0, 0.0], [0.0, 4.0]])
+        layer = PrototypeEmbeddingToConcept(2, ann, prototypes, temperature=2.0)
+        x = torch.tensor([[[5.0, 0.0], [0.0, 6.0]]])
+
+        logits = layer(x)
+        expected = torch.tensor([[[2.0, 0.0], [0.0, 2.0]]])
+        assert logits.shape == (1, 2, 2)
+        torch.testing.assert_close(logits, expected)
+
+    def test_custom_similarity_and_input_validation(self):
+        ann = _binary_annotations(1)
+
+        def dot(embeddings, prototypes):
+            return embeddings @ prototypes.T
+
+        layer = PrototypeEmbeddingToConcept(
+            2, ann, torch.tensor([[1.0, 2.0]]), temperature=3.0, similarity=dot
+        )
+        torch.testing.assert_close(layer(torch.tensor([[2.0, 1.0]])), torch.tensor([[12.0]]))
+        with pytest.raises(ValueError, match="final size"):
+            layer(torch.randn(2, 3))
+
+    def test_output_follows_input_dtype_and_gradients(self):
+        ann = _binary_annotations(1)
+        layer = PrototypeEmbeddingToConcept(3, ann, torch.randn(1, 3))
+        x = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
+        logits = layer(x)
+        assert logits.dtype == torch.float64
+        logits.sum().backward()
+        assert x.grad is not None
+        assert layer.state_prototypes.grad is None
+
+    def test_checkpoint_restores_prototype_semantics(self):
+        ann = _binary_annotations(2)
+        layer = PrototypeEmbeddingToConcept(
+            3, ann, torch.randn(2, 3), prototype_labels=["striped", "red"]
+        )
+        restored = PrototypeEmbeddingToConcept(3, ann, torch.zeros(2, 3))
+        restored.load_state_dict(layer.state_dict())
+        assert restored.prototype_labels == ("striped", "red")
+        torch.testing.assert_close(restored.state_prototypes, layer.state_prototypes)

--- a/torch_concepts/nn/__init__.py
+++ b/torch_concepts/nn/__init__.py
@@ -31,6 +31,7 @@ from .modules.mid.activations import DefaultActivation
 from .modules.low.encoders.linear import LinearEmbeddingToConcept
 from .modules.low.encoders.whitening import ConceptWhitening, WhitenedEmbeddingToConcept
 from .modules.low.encoders.cav import CAVEmbeddingToConcept
+from .modules.low.encoders.prototype import PrototypeEmbeddingToConcept
 
 # Predictors
 from .modules.low.predictors.call import CallableConceptToConcept
@@ -139,6 +140,7 @@ __all__ = [
     "ConceptWhitening",
     "WhitenedEmbeddingToConcept",
     "CAVEmbeddingToConcept",
+    "PrototypeEmbeddingToConcept",
 
     # Predictor classes
     "LinearConceptToConcept",

--- a/torch_concepts/nn/modules/high/models/cbm.py
+++ b/torch_concepts/nn/modules/high/models/cbm.py
@@ -19,9 +19,10 @@ References
 ----------
 Koh et al. "Concept Bottleneck Models", ICML 2020. https://proceedings.mlr.press/v119/koh20a.html
 """
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import torch
+import torch.nn as nn
 
 from torch.distributions import Bernoulli, OneHotCategorical, Normal
 
@@ -70,6 +71,12 @@ class ConceptBottleneckModel(BipartiteModel):
         the level factories). ``None`` (default) and ``True`` group homogeneous
         concepts into the minimum number of plates — even a lone concept becomes a
         single-member plate. ``False`` uses one individual variable per concept.
+    concept_encoder_factory : callable, optional
+        Factory ``(in_embeddings, out_concepts) -> nn.Module`` used instead of
+        the default linear latent-to-concept encoder. ``out_concepts`` is the
+        annotation subset for one concept plate, so custom encoders can align
+        fixed state prototypes with their output logits. This path supports only
+        binary and categorical intermediate concepts.
     **kwargs
         Forwarded to :class:`BaseModel` (e.g. ``backbone``, ``latent_size``, and
         the Lightning training arguments).
@@ -97,6 +104,7 @@ class ConceptBottleneckModel(BipartiteModel):
         train_inference_kwargs: Optional[dict] = None,
         lightning: bool = False,
         plate: Optional[bool] = None,
+        concept_encoder_factory: Optional[Callable[[int, Annotations], nn.Module]] = None,
         **kwargs,
     ):
         super().__init__(
@@ -107,6 +115,16 @@ class ConceptBottleneckModel(BipartiteModel):
             plate=plate,
             **kwargs,
         )
+        if concept_encoder_factory is not None:
+            intermediate = self.concept_annotations.subset(
+                self.intermediate_concept_names
+            )
+            if any(kind == "continuous" for kind in intermediate.types):
+                raise ValueError(
+                    "concept_encoder_factory supports binary and categorical "
+                    "intermediate concepts only."
+                )
+        self.concept_encoder_factory = concept_encoder_factory
         # One builder for both layouts (plate / individual, decided per level).
         self.pgm = self._build_model()
 
@@ -159,13 +177,25 @@ class ConceptBottleneckModel(BipartiteModel):
         tasks = self.build_concept_variables(self.task_names, plate_name="tasks")
 
         # latent → concepts: one encoder per concept variable (per group).
+        def encoder_for(cvar):
+            if self.concept_encoder_factory is None:
+                return LazyConstructor(LinearEmbeddingToConcept)
+            annotation = self.concept_annotations.subset(cvar.members)
+            encoder = self.concept_encoder_factory(self.latent_size, annotation)
+            if not isinstance(encoder, nn.Module):
+                raise TypeError(
+                    "concept_encoder_factory must return an nn.Module, got "
+                    f"{type(encoder).__name__}."
+                )
+            return encoder
+
         encoders = ParametricCPD(
             variable=concepts,
             parents=[latent_var],
             parametrization=[
                 self._flexible_parametrization(
                     variable=c,
-                    first=LazyConstructor(LinearEmbeddingToConcept), # parameterization for the first parameter
+                    first=encoder_for(c), # parameterization for the first parameter
                     second=LazyConstructor(LinearEmbeddingToConcept), # parameterization for the second parameter
                     # nn.Softplus() or ScaleTrilActivation will be 
                     # attached automatically to the second head for continuous variables.

--- a/torch_concepts/nn/modules/low/encoders/prototype.py
+++ b/torch_concepts/nn/modules/low/encoders/prototype.py
@@ -1,0 +1,118 @@
+"""Prototype-grounded encoders for label-free concept supervision."""
+from typing import Callable, Optional, Sequence, Union
+
+import torch
+import torch.nn.functional as F
+
+from torch_concepts import Annotations
+from torch_concepts.nn.modules.low.base.layer import BaseConceptLayer
+
+
+class PrototypeEmbeddingToConcept(BaseConceptLayer):
+    """Map compatible embeddings to concept logits with frozen prototypes.
+
+    This layer grounds each concept state in a fixed prototype from the same
+    embedding space as the input. It is therefore suitable for settings such as
+    CLIP, where image embeddings and text embeddings can be compared directly.
+    Binary concepts use one positive-state prototype; categorical concepts use
+    one prototype per state. ``state_prototypes`` must consequently contain one
+    row per flattened output state in ``out_concepts`` order.
+
+    The layer has no learned projection or bias. Its prototypes are buffers, so
+    task-only optimisation cannot move their external semantic grounding.
+
+    Args:
+        in_embeddings: Embedding dimension, or its annotations.
+        out_concepts: Binary/categorical output concept annotations.
+        state_prototypes: Tensor with shape ``(out_concepts.size,
+            in_embeddings)`` in the shared embedding space.
+        temperature: Positive scale applied to similarity scores.
+        similarity: Optional scorer with signature ``(embeddings, prototypes)
+            -> scores``. Defaults to cosine similarity.
+        prototype_labels: Optional semantic labels, one per prototype, retained
+            in checkpoints for inspection.
+    """
+
+    def __init__(
+        self,
+        in_embeddings: Union[int, Annotations],
+        out_concepts: Annotations,
+        state_prototypes: torch.Tensor,
+        *,
+        temperature: float = 12.0,
+        similarity: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+        prototype_labels: Optional[Sequence[str]] = None,
+    ) -> None:
+        super().__init__(in_embeddings=in_embeddings, out_concepts=out_concepts)
+        if any(kind == "continuous" for kind in out_concepts.types):
+            raise ValueError(
+                "PrototypeEmbeddingToConcept supports binary and categorical "
+                "concepts only."
+            )
+        if state_prototypes.ndim != 2:
+            raise ValueError(
+                "state_prototypes must have shape "
+                "(n_state_logits, embedding_size)."
+            )
+        expected_shape = (self.out_concepts_shape, self.in_embeddings_shape)
+        if tuple(state_prototypes.shape) != expected_shape:
+            raise ValueError(
+                "Expected state_prototypes with shape "
+                f"{expected_shape}, got {tuple(state_prototypes.shape)}."
+            )
+        if temperature <= 0:
+            raise ValueError("temperature must be positive.")
+
+        self.register_buffer("state_prototypes", state_prototypes.detach().clone())
+        self.register_buffer("temperature", torch.tensor(float(temperature)))
+        self.similarity = similarity or self._cosine_similarity
+
+        labels = tuple(prototype_labels or self._default_prototype_labels(out_concepts))
+        if len(labels) != self.out_concepts_shape:
+            raise ValueError(
+                f"Expected {self.out_concepts_shape} prototype labels, got {len(labels)}."
+            )
+        self.prototype_labels = labels
+
+    @staticmethod
+    def _cosine_similarity(
+        embeddings: torch.Tensor,
+        prototypes: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return one cosine similarity per prototype."""
+        return F.normalize(embeddings, dim=-1) @ F.normalize(prototypes, dim=-1).T
+
+    @staticmethod
+    def _default_prototype_labels(annotations: Annotations) -> tuple[str, ...]:
+        """Derive stable state labels from concept annotations."""
+        labels = []
+        for name in annotations.labels:
+            concept = annotations.concept(name)
+            if concept.is_binary:
+                labels.append(name)
+            else:
+                labels.extend(f"{name}:{state}" for state in concept.states)
+        return tuple(labels)
+
+    def get_extra_state(self) -> dict:
+        """Store non-tensor prototype semantics in a state dictionary."""
+        return {"prototype_labels": self.prototype_labels}
+
+    def set_extra_state(self, state: dict) -> None:
+        self.prototype_labels = tuple(state["prototype_labels"])
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        """Return scaled prototype-similarity logits."""
+        if embeddings.shape[-1] != self.in_embeddings_shape:
+            raise ValueError(
+                f"Expected embeddings with final size {self.in_embeddings_shape}, got "
+                f"{embeddings.shape[-1]}."
+            )
+        scores = self.similarity(embeddings, self.state_prototypes.to(embeddings))
+        expected_shape = (*embeddings.shape[:-1], self.out_concepts_shape)
+        if tuple(scores.shape) != expected_shape:
+            raise ValueError(
+                "similarity must return one score per prototype, with shape "
+                f"{expected_shape}; got {tuple(scores.shape)}."
+            )
+        return scores * self.temperature.to(scores)


### PR DESCRIPTION
Adds label-free CBM functionality using frozen prototype similarity in a shared embedding space.
The similarity function is customizable by the user.

- Adds `PrototypeEmbeddingToConcept`
- Adds `concept_encoder_factory` to `ConceptBottleneckModel`
- Includes docs and task-only training tests (`c_true` not required)